### PR TITLE
Add osm tag railway=ferry as valid way

### DIFF
--- a/basic.lua
+++ b/basic.lua
@@ -57,7 +57,8 @@ function process_way(profile, way, result, relations)
     elseif (
         data.railway ~= 'rail' and
         data.railway ~= 'turntable' and
-        data.railway ~= 'traverser'
+        data.railway ~= 'traverser' and
+        data.railway  ~= 'ferry'
     ) then
         return
     -- Remove military and tourism rails


### PR DESCRIPTION
Hello,
This pull request is about adding some existing connections where a train ships into a ferry boat.  Currently, 3 cases (8 ways) are flagged as railway=ferry around the world in OSM.
* Messina
* New York
* Germany
See attachments.
[ferry trains.docx](https://github.com/railnova/osrm-train-profile/files/5879866/ferry.trains.docx)

KR

Jon
